### PR TITLE
use context.drawing_cards for burnt cards

### DIFF
--- a/lovely.toml
+++ b/lovely.toml
@@ -3,19 +3,6 @@ version = "1.0.0"
 dump_lua = true
 priority = 12
 
-# Burnt card extra card draw
-[[patches]]
-[patches.pattern]
-target = '''functions/state_events.lua'''
-pattern = "for i=1, hand_space do*"
-position = "at"
-payload = '''
-local draw = hand_space + (G.GAME.prism_extra_draw or 0)
-G.GAME.prism_extra_draw = 0
-for i=1, draw do
-'''
-match_indent = true
-
 #ice cards card count
 [[patches]]
 [patches.pattern]

--- a/main.lua
+++ b/main.lua
@@ -82,6 +82,11 @@ function SMODS.current_mod.calculate(self, context)
 	if context.fix_probability and G.GAME and G.GAME.prism_fortune_cookie then
 		return {numerator = context.denominator}
 	end
+	if context.drawing_cards and G.GAME.prism_extra_draw > 0 then
+		local extra_draw = G.GAME.prism_extra_draw
+		G.GAME.prism_extra_draw = 0
+		return {modify = context.amount + extra_draw}
+	end
 end
 
 if G.PRISM.config.jokers_enabled then  SMODS.load_file('objects/jokers.lua')() end


### PR DESCRIPTION
there were crashes with how this was implemented previously. this should make it reliable and interact with other mods better as well